### PR TITLE
Minor fix in form.tpl

### DIFF
--- a/admin-dev/themes/default/template/helpers/form/form.tpl
+++ b/admin-dev/themes/default/template/helpers/form/form.tpl
@@ -489,7 +489,6 @@
 											</script>
 										{/if}
 									{/if}
-									<div class="input-group">
 									{if isset($input.maxchar) && $input.maxchar}</div>{/if}
 								{elseif $input.type == 'checkbox'}
 									{if isset($input.expand)}


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | There is a HTML element in the `form.tpl` file that causes it to break the design. The error mainly affects when using the `tabs` in the array of the `HelperForm()`.
| Type?         | bug fix
| Category?     | BO
| BC breaks?    | yes
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | In a module configurator, create a form using the `HelperForm` class, use tabs, and a couple of `textarea` inputs, then create a extra panel in the bottom and you will see this error with the overlapping elements, like this: https://i.postimg.cc/5fzSPc2t/Screen-Shot-2018-10-23-at-5-05-44-PM.png
